### PR TITLE
Build system: Wrap clang-format to show diff

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ if (CLANG_FORMAT_EXECUTABLE)
 	message(STATUS "Enabling format target")
 
 	add_custom_target(
-		format ${CLANG_FORMAT_EXECUTABLE} -style=file -i ${MAVLINK_SUITE_FORMAT_SRCS})
+        format ${CMAKE_CURRENT_SOURCE_DIR}/tools/run_clang_format.sh ${CLANG_FORMAT_EXECUTABLE} ${MAVLINK_SUITE_FORMAT_SRCS})
 endif()
 
 find_program(CLANG_TIDY_EXECUTABLE

--- a/tools/run_clang_format.sh
+++ b/tools/run_clang_format.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Script to run clang-format and show diff.
+#
+# Usage: ./run_clang_format.sh /usr/bin/clang-format src/main.cpp src/tests/base.h ...
+
+# Keep clang-format executable for later.
+clang_format_executable=$1
+
+# Get remaining args
+shift
+
+# Use colordiff if available
+if command -v colordiff >/dev/null 2>&1; then
+    diff_cmd=colordiff
+else
+    diff_cmd=diff
+fi
+
+# Keep track of errors for the exit value
+error_found=false
+
+# Go through files and run clang-format in place and show diff against .orig file.
+for file in $@; do
+
+    cp $file $file.orig
+    result=`clang-format -style=file -i $file`
+
+    if ! cmp $file $file.orig >/dev/null 2>&1; then
+        echo "Changed $file:"
+        $diff_cmd $file.orig $file
+        error_found=true
+    fi
+
+    rm $file.orig
+done
+
+if [ "$error_found" = true ]; then
+    exit 1
+fi


### PR DESCRIPTION
This adds a bash script around clang format which allows us to show a diff if the formatting has changed.