### PR TITLE
cmake: add DronecodeSDK using ExternalProject_Add

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,6 @@ ExternalProject_Add(third_party_dronecode_sdk
     GIT_REPOSITORY https://github.com/Dronecode/DronecodeSDK.git
     GIT_TAG v0.13.0
     BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/build_dronecode_sdk
-    #INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/build_dronecode_sdk/install"
     INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target install
     )
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/build_dronecode_sdk/install/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,33 +32,7 @@ else()
     add_definitions("-Wall -Wextra -Werror")
 endif()
 
-include(ExternalProject)
-
-# add SDK
-ExternalProject_Add(third_party_dronecode_sdk
-    SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/third_party/DronecodeSDK
-    CMAKE_ARGS
-        -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/build_dronecode_sdk/install
-    GIT_REPOSITORY https://github.com/Dronecode/DronecodeSDK.git
-    GIT_TAG v0.13.0
-    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/build_dronecode_sdk
-    INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target install
-    )
-include_directories(${CMAKE_CURRENT_BINARY_DIR}/build_dronecode_sdk/install/include)
-link_directories(${CMAKE_CURRENT_BINARY_DIR}/build_dronecode_sdk/install/lib)
-
-# add YAML (build from source)
-ExternalProject_Add(third_party_yaml
-    SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/third_party/yaml-cpp
-    CMAKE_ARGS
-        -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
-    GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
-    GIT_TAG yaml-cpp-0.6.2
-    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/build_yaml
-    INSTALL_COMMAND ""
-    )
-include_directories(${CMAKE_CURRENT_BINARY_DIR}/third_party/yaml-cpp/include)
-
+include(cmake/dependencies.cmake)
 
 add_executable(mavlink_testing_suite
     src/main.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,9 @@ else()
     add_definitions("-Wall -Wextra -Werror")
 endif()
 
-# add SDK
 include(ExternalProject)
+
+# add SDK
 ExternalProject_Add(third_party_dronecode_sdk
     SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/third_party/DronecodeSDK
     CMAKE_ARGS
@@ -47,7 +48,6 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}/build_dronecode_sdk/install/incl
 link_directories(${CMAKE_CURRENT_BINARY_DIR}/build_dronecode_sdk/install/lib)
 
 # add YAML (build from source)
-include(ExternalProject)
 ExternalProject_Add(third_party_yaml
     SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/third_party/yaml-cpp
     CMAKE_ARGS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,11 +25,6 @@ string(TIMESTAMP SUITE_VERSION_BUILD_TIMESTAMP "%Y-%m-%dT%H:%M:%S.000000Z" UTC)
 # Specify at least C++11
 set(CMAKE_CXX_STANDARD 11)
 
-set(SDK_INSTALL_DIR "" CACHE STRING "SDK installation directory")
-if("${SDK_INSTALL_DIR}" STREQUAL "")
-	message( FATAL_ERROR "Pass the SDK installation directory via -DSDK_INSTALL_DIR=<directory>" )
-endif()
-
 # Enable strict handling of warnings
 if(MSVC)
     add_definitions("-WX -W2")
@@ -38,12 +33,23 @@ else()
 endif()
 
 # add SDK
-include_directories(${SDK_INSTALL_DIR}/include)
-link_directories(${SDK_INSTALL_DIR}/lib)
+include(ExternalProject)
+ExternalProject_Add(third_party_dronecode_sdk
+    SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/third_party/DronecodeSDK
+    CMAKE_ARGS
+        -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/build_dronecode_sdk/install
+    GIT_REPOSITORY https://github.com/Dronecode/DronecodeSDK.git
+    GIT_TAG v0.13.0
+    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/build_dronecode_sdk
+    #INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/build_dronecode_sdk/install"
+    INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target install
+    )
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/build_dronecode_sdk/install/include)
+link_directories(${CMAKE_CURRENT_BINARY_DIR}/build_dronecode_sdk/install/lib)
 
 # add YAML (build from source)
 include(ExternalProject)
-ExternalProject_Add(yaml
+ExternalProject_Add(third_party_yaml
     SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/third_party/yaml-cpp
     CMAKE_ARGS
         -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
@@ -62,7 +68,10 @@ add_executable(mavlink_testing_suite
     src/tests/mission.cpp
     src/tests/param.cpp
 )
-add_dependencies(mavlink_testing_suite yaml)
+add_dependencies(mavlink_testing_suite
+    third_party_yaml
+    third_party_dronecode_sdk
+    )
 
 target_link_libraries(mavlink_testing_suite
     dronecode_sdk

--- a/README.md
+++ b/README.md
@@ -4,24 +4,14 @@ This project aims to provide a testing suite to test standard compliance of
 MAVLink-enabled components/systems.
 The design intent is described in https://docs.google.com/document/d/1zwUZ-VUmq2pmCuGn1kY6BRS48-GiSXcMO5TUfnTpqmI
 
-Note: the implementation here is very preliminary.
-
-### Build Instructions
-- install the Dronecode SDK (from source):
-  ```
-  git clone --recursive https://github.com/Dronecode/DronecodeSDK.git
-  cd DronecodeSDK
-  mkdir install
-  export INSTALL_PREFIX=$(pwd)/install
-  make default install
-  ```
-- build the testing suite:
+- Build the testing suite:
   ```
   mkdir build && cd build
-  cmake .. -DSDK_INSTALL_DIR=${INSTALL_PREFIX}
+  cmake ..
   make
   ```
 ### Running the Test(s)
+
 - Start the SITL simulation
 - Then run the tests in the `build` directory with:
   ```

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -1,0 +1,26 @@
+include(ExternalProject)
+
+# add SDK
+ExternalProject_Add(third_party_dronecode_sdk
+    SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/third_party/DronecodeSDK
+    CMAKE_ARGS
+        -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/build_dronecode_sdk/install
+    GIT_REPOSITORY https://github.com/Dronecode/DronecodeSDK.git
+    GIT_TAG v0.13.0
+    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/build_dronecode_sdk
+    INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target install
+    )
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/build_dronecode_sdk/install/include)
+link_directories(${CMAKE_CURRENT_BINARY_DIR}/build_dronecode_sdk/install/lib)
+
+# add YAML (build from source)
+ExternalProject_Add(third_party_yaml
+    SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/third_party/yaml-cpp
+    CMAKE_ARGS
+        -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+    GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
+    GIT_TAG yaml-cpp-0.6.2
+    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/build_yaml
+    INSTALL_COMMAND ""
+    )
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/third_party/yaml-cpp/include)

--- a/run_ci.sh
+++ b/run_ci.sh
@@ -1,29 +1,12 @@
 #! /bin/bash
 
 BUILD_DIR=build_ci
-SDK_INSTALL_DIR="$(pwd)/DronecodeSDK-install"
 
 set -e
 
-# Get the SDK - for now we use the latest develop version
-if [ -d DronecodeSDK ]; then
-	# If it's already here, make sure it's up-to-date and clean
-	pushd DronecodeSDK
-	git pull
-	make clean
-	popd
-else
-	git clone --recursive https://github.com/Dronecode/DronecodeSDK.git || true
-fi
-pushd DronecodeSDK
-[ ! -d "$SDK_INSTALL_DIR" ] && mkdir -p "$SDK_INSTALL_DIR"
-export INSTALL_PREFIX="$SDK_INSTALL_DIR"
-make default install
-popd
-
 [ ! -d "$BUILD_DIR" ] && mkdir -p "$BUILD_DIR"
 cd "$BUILD_DIR"
-cmake .. -DSDK_INSTALL_DIR="${SDK_INSTALL_DIR}"
+cmake ..
 make
 
 set +e


### PR DESCRIPTION
This means that we can pin the version and prevent errors where we run it against an outdated library version.

Would prevent cases like #6.