### PR TITLE
parm: add test for float param

### DIFF
--- a/config/autopilot.yaml
+++ b/config/autopilot.yaml
@@ -4,5 +4,12 @@ tests:
 
     - name: ParamChange
       param_name: SYS_HITL
+      param_type: int32
       param_set_value: 1
       param_reset_value: 0
+
+    - name: ParamChange
+      param_name: MPC_XY_CRUISE
+      param_type: float
+      param_set_value: 10.0
+      param_reset_value: 5.0

--- a/src/tests/param.cpp
+++ b/src/tests/param.cpp
@@ -1,8 +1,11 @@
 
 #include "param.h"
+#include <cmath>
+#include <cstdint>
 #include <future>
 #include <iostream>
 #include <memory>
+#include <stdexcept>
 #include <vector>
 
 using namespace std;
@@ -14,27 +17,107 @@ REGISTER_TEST(ParamChange);
 
 ParamChange::ParamChange(const Context& context) : TestBase(context), _params_raw(context.system) {}
 
+void ParamChange::setParam()
+{
+    if (isInt32()) {
+        int32_t set_value = long(std::round(_config.set_value));
+        cout << "Resetting int32 param " << _config.name << " to " << set_value << endl;
+        ParamsRaw::Result set_result = _params_raw.set_param_int(_config.name, set_value);
+        EXPECT_EQ(set_result, ParamsRaw::Result::SUCCESS);
+
+    } else if (isFloat()) {
+        cout << "Resetting float param " << _config.name << " to " << _config.set_value << endl;
+        ParamsRaw::Result set_result = _params_raw.set_param_float(_config.name, _config.set_value);
+        EXPECT_EQ(set_result, ParamsRaw::Result::SUCCESS);
+
+    } else {
+        throw std::invalid_argument("Unknown param type");
+    }
+}
+
+void ParamChange::resetParam()
+{
+    if (isInt32()) {
+        int32_t reset_value = long(std::round(_config.reset_value));
+        cout << "Setting int32 param " << _config.name << " to " << reset_value << endl;
+        ParamsRaw::Result reset_result = _params_raw.set_param_int(_config.name, reset_value);
+        EXPECT_EQ(reset_result, ParamsRaw::Result::SUCCESS);
+
+    } else if (isFloat()) {
+        cout << "Setting float param " << _config.name << " to " << _config.reset_value << endl;
+        ParamsRaw::Result set_result =
+            _params_raw.set_param_float(_config.name, _config.reset_value);
+        EXPECT_EQ(set_result, ParamsRaw::Result::SUCCESS);
+
+    } else {
+        throw std::invalid_argument("Unknown param type");
+    }
+}
+
+void ParamChange::verifySetParam()
+{
+    if (isInt32()) {
+        int32_t set_value = long(std::round(_config.set_value));
+        cout << "Checking set param " << _config.name << " is " << set_value << endl;
+        const std::pair<ParamsRaw::Result, int> get_result =
+            _params_raw.get_param_int(_config.name);
+
+        EXPECT_EQ(get_result.first, ParamsRaw::Result::SUCCESS);
+        EXPECT_EQ(get_result.second, set_value);
+
+    } else if (isFloat()) {
+        cout << "Checking set param " << _config.name << " is " << _config.set_value << endl;
+        const std::pair<ParamsRaw::Result, float> get_result =
+            _params_raw.get_param_float(_config.name);
+
+        EXPECT_EQ(get_result.first, ParamsRaw::Result::SUCCESS);
+        EXPECT_EQ(get_result.second, _config.set_value);
+
+    } else {
+        throw std::invalid_argument("Unknown param type");
+    }
+}
+
+void ParamChange::verifyResetParam()
+{
+    if (isInt32()) {
+        int32_t reset_value = long(std::round(_config.reset_value));
+        cout << "Checking reset param " << _config.name << " is " << reset_value << endl;
+        const std::pair<ParamsRaw::Result, int> get_result =
+            _params_raw.get_param_int(_config.name);
+
+        EXPECT_EQ(get_result.first, ParamsRaw::Result::SUCCESS);
+        EXPECT_EQ(get_result.second, reset_value);
+
+    } else if (isFloat()) {
+        cout << "Checking reset param " << _config.name << " is " << _config.reset_value << endl;
+        const std::pair<ParamsRaw::Result, float> get_result =
+            _params_raw.get_param_float(_config.name);
+
+        EXPECT_EQ(get_result.first, ParamsRaw::Result::SUCCESS);
+        EXPECT_EQ(get_result.second, _config.reset_value);
+
+    } else {
+        throw std::invalid_argument("Unknown param type");
+    }
+}
+
 void ParamChange::run()
 {
-    cout << "Setting param " << _config.name << " to " << _config.set_value << endl;
-    ParamsRaw::Result set_result1 = _params_raw.set_param_int(_config.name, _config.set_value);
-    EXPECT_EQ(set_result1, ParamsRaw::Result::SUCCESS);
+    setParam();
+    verifySetParam();
+    resetParam();
+    verifyResetParam();
+}
 
-    cout << "Checking param " << _config.name << " is " << _config.set_value << endl;
-    const std::pair<ParamsRaw::Result, int> get_result1 = _params_raw.get_param_int(_config.name);
+bool ParamChange::isInt32()
+{
+    return _config.type == "int32";
+}
 
-    EXPECT_EQ(get_result1.first, ParamsRaw::Result::SUCCESS);
-    EXPECT_EQ(get_result1.second, _config.set_value);
-
-    cout << "Setting param " << _config.name << " to " << _config.reset_value << endl;
-    ParamsRaw::Result set_result2 = _params_raw.set_param_int(_config.name, _config.reset_value);
-    EXPECT_EQ(set_result2, ParamsRaw::Result::SUCCESS);
-
-    cout << "Checking param " << _config.name << " is " << _config.reset_value << endl;
-    const std::pair<ParamsRaw::Result, int> get_result2 = _params_raw.get_param_int(_config.name);
-
-    EXPECT_EQ(get_result2.first, ParamsRaw::Result::SUCCESS);
-    EXPECT_EQ(get_result2.second, _config.reset_value);
+bool ParamChange::isFloat()
+{
+    return _config.type == "float";
 }
 
 }  // namespace tests

--- a/src/tests/param.h
+++ b/src/tests/param.h
@@ -9,19 +9,21 @@ namespace tests
 {
 /**
  * @class ParamChange
- * Test setting parameter.
+ * Test setting and getting parameter.
  */
 class ParamChange : public TestBase
 {
 public:
     struct Config {
         std::string name{};
-        int set_value{0};
-        int reset_value{0};
+        std::string type{};
+        float set_value{0.0f};
+        float reset_value{0.0f};
 
         void serialize(ConfigProvider& c)
         {
             c("param_name", name);
+            c("param_type", type);
             c("param_set_value", set_value);
             c("param_reset_value", reset_value);
         }
@@ -36,6 +38,13 @@ protected:
     void serialize(ConfigProvider& c) override { _config.serialize(c); }
 
 private:
+    void setParam();
+    void verifySetParam();
+    void resetParam();
+    void verifyResetParam();
+    bool isInt32();
+    bool isFloat();
+
     dronecode_sdk::ParamsRaw _params_raw;
     Config _config;
 };


### PR DESCRIPTION
We should not only test int32 params but also float since these are the two params primarily used for PX4.