### PR TITLE
mission: only drop mission messages for now

### DIFF
--- a/src/tests/mission.h
+++ b/src/tests/mission.h
@@ -50,6 +50,7 @@ private:
                          const std::vector<std::shared_ptr<dcsdk::MissionItem>>& items_b);
 
     void dropMessages(float ratio);
+    bool shouldDropMissionMessage(const mavlink_message_t& message, float ratio);
 
     dcsdk::Mission _mission;
     dcsdk::MavlinkPassthrough _mavlink_passthrough;


### PR DESCRIPTION
To make test results more reproducible it makes sense to only filter out
mission specific messages. That way we don't depend on the timing and
rate of the rest of the messages and should get consistent drops for
messages which matter for the mission transfer.

Note that the MISSION_ACK message is not dropped for now because there
is no retransmission in the protocol for it.